### PR TITLE
Put initializer on window

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,16 +11,5 @@
         <span data-view="flip"></span>
       </div>
     </div>
-    <script>
-      function setupFlip(tick) {
-        Tick.helper.interval(function() {
-          tick.value++;
-          tick.root.setAttribute(
-            'aria-label', 
-            tick.value
-          );
-        }, 1000);
-      }
-    </script>
   </body>
 </html>

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,15 +1,9 @@
-//import Tick from '@pqina/flip'
-import '@pqina/flip/dist/flip.js'
-import '../styles/main.scss'
+import "@pqina/flip/dist/flip.js";
+import "../styles/main.scss";
 
-/*
-function setupFlip(tick) {
-  Tick.helper.interval(function() {
+window.setupFlip = function (tick) {
+  Tick.helper.interval(function () {
     tick.value++;
-    tick.root.setAttribute(
-      'aria-label', 
-      tick.value
-    );
+    tick.root.setAttribute("aria-label", tick.value);
   }, 1000);
-}
-*/
+};


### PR DESCRIPTION
Since `setupFlip` is "called" from a data attribute on `.tick`: `data-did-init`, I can only assume that the function needs to be global. Setting the function on `window` makes it global.